### PR TITLE
relax ncurses-term to 6.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+foot (1.15.3-2deepin) unstable; urgency=medium
+
+  * relax ncurses-term to 6.3
+
+ -- rewine <lhongxu@outlook.com>  Fri, 11 Aug 2023 15:00:30 +0800
+
 foot (1.15.3-1deepin) UNRELEASED; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Rules-Requires-Root: no
 Package: foot
 Architecture: any
 Provides: x-terminal-emulator
-Depends: ${misc:Depends}, ${shlibs:Depends}, ncurses-term (>= 6.4+20230625-2)
+Depends: ${misc:Depends}, ${shlibs:Depends}, ncurses-term (>= 6.3)
 Suggests: foot-themes
 Description: Fast, lightweight and minimalistic Wayland terminal emulator
  The fast, lightweight and minimalistic Wayland terminal emulator.
@@ -49,7 +49,7 @@ Package: foot-terminfo
 Replaces: foot (<< 1.5.3-2)
 Breaks: foot (<< 1.5.3-2)
 Architecture: all
-Depends: ${misc:Depends}, ncurses-term (>= 6.4+20230625-2)
+Depends: ${misc:Depends}, ncurses-term (>= 6.3)
 Section: oldlibs
 Description: Fast, lightweight and minimalistic Wayland terminal emulator (terminfo files)
  This is a transitional package. It can safely be removed.


### PR DESCRIPTION
https://github.com/deepin-community/ncurses/pull/1  not esay to upgrade ncurses

At least make foot works with ncurses 6.3 

@UTsweetyfish 

